### PR TITLE
年度別、月別、realデータをいれました。

### DIFF
--- a/src/apollo.ts
+++ b/src/apollo.ts
@@ -28,6 +28,7 @@ export const nextMonth = () => {
 export const logUserIn = (token: string) => {
   localStorage.setItem(TOKEN, token);
   isLoggedInVar(true);
+  window.location.reload();
 };
 export const logUserOut = () => {
   localStorage.removeItem(TOKEN);

--- a/src/components/homeStyle/HomeDateSelector.tsx
+++ b/src/components/homeStyle/HomeDateSelector.tsx
@@ -23,12 +23,10 @@ const HomeDateSelector = () => {
   const clickedMonth = useReactiveVar(displayMonth);
   const clickedYear = useReactiveVar(displayYear);
   const sameThisYM = () => {
-    if (
+    return (
       clickedYear.year === new Date().getFullYear() &&
       clickedMonth.month === new Date().getMonth() + 1
-    ) {
-      return true;
-    } else return false;
+    );
   };
   return (
     <>

--- a/src/components/homeStyle/HomeSummary.tsx
+++ b/src/components/homeStyle/HomeSummary.tsx
@@ -107,22 +107,31 @@ const HomeSummary = ({ user }: Props) => {
       <MoneyImg src="https://cdn.pixabay.com/photo/2021/06/27/12/40/money-6368673_960_720.png"></MoneyImg>
       <WelcomeText>こんにちは。{user}様！</WelcomeText>
       <WelcomeText>今までの収支を確認してください。</WelcomeText>
-      <TotalAmount amount={total}>{`￥${total
-        .toString()
-        .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`}</TotalAmount>
+      <TotalAmount amount={total}>
+        {new Intl.NumberFormat("ja-JP", {
+          style: "currency",
+          currency: "JPY",
+        }).format(total)}
+      </TotalAmount>
       <AmountDevideBox>
         <Income>
           <div>入ったお金</div>{" "}
-          <span>{`￥${income
-            .toString()
-            .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`}</span>
+          <span>
+            {new Intl.NumberFormat("ja-JP", {
+              style: "currency",
+              currency: "JPY",
+            }).format(income)}
+          </span>
         </Income>
         <ColDevidedLine></ColDevidedLine>
         <Expend>
           <div>出たお金</div>
-          <span>{`￥${expend
-            .toString()
-            .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`}</span>
+          <span>
+            {new Intl.NumberFormat("ja-JP", {
+              style: "currency",
+              currency: "JPY",
+            }).format(expend)}
+          </span>
         </Expend>
       </AmountDevideBox>
     </SummaryBox>

--- a/src/components/homeStyle/HomeSummary.tsx
+++ b/src/components/homeStyle/HomeSummary.tsx
@@ -1,6 +1,6 @@
 import { useQuery, useReactiveVar } from "@apollo/client";
 import styled from "styled-components";
-import { nowMonth, nowYear } from "../../apollo";
+import { displayMonth, displayYear } from "../../apollo";
 import { MoneyList } from "../../generated/graphql";
 import { VIEW_MONEY_QUERY } from "../../routes/pages/Home";
 
@@ -77,8 +77,8 @@ type Props = {
   user: string;
 };
 const HomeSummary = ({ user }: Props) => {
-  const clickedMonth = useReactiveVar(nowMonth);
-  const clickedYear = useReactiveVar(nowYear);
+  const clickedMonth = useReactiveVar(displayMonth);
+  const clickedYear = useReactiveVar(displayYear);
   const { data: moneyInfo } = useQuery(VIEW_MONEY_QUERY, {
     variables: {
       year: clickedYear.year,

--- a/src/components/homeStyle/HomeSummary.tsx
+++ b/src/components/homeStyle/HomeSummary.tsx
@@ -1,4 +1,8 @@
+import { useQuery, useReactiveVar } from "@apollo/client";
 import styled from "styled-components";
+import { nowMonth, nowYear } from "../../apollo";
+import { MoneyList } from "../../generated/graphql";
+import { VIEW_MONEY_QUERY } from "../../routes/pages/Home";
 
 const SummaryBox = styled.div`
   display: flex;
@@ -18,12 +22,13 @@ const WelcomeText = styled.h1`
   font-weight: 600;
   margin: 10px;
 `;
-const TotalAmount = styled.h1`
+const TotalAmount = styled.h1<{ amount: number }>`
   padding: 5px;
   margin: 10px 0;
   font-size: 28px;
   font-weight: 800px;
-  color: ${(props) => props.theme.mainColor};
+  color: ${(props) =>
+    props.amount > 0 ? props.theme.plusColor : props.theme.minusColor};
 `;
 const AmountDevideBox = styled.div`
   border: 1px solid ${(props) => props.theme.borderColor};
@@ -68,21 +73,56 @@ const Expend = styled.h2`
     color: ${(props) => props.theme.minusColor};
   }
 `;
-const HomeSummary = () => {
+type Props = {
+  user: string;
+};
+const HomeSummary = ({ user }: Props) => {
+  const clickedMonth = useReactiveVar(nowMonth);
+  const clickedYear = useReactiveVar(nowYear);
+  const { data: moneyInfo } = useQuery(VIEW_MONEY_QUERY, {
+    variables: {
+      year: clickedYear.year,
+      month: clickedMonth.month,
+    },
+  });
+  let total = 0;
+  let income = 0;
+  let expend = 0;
+
+  if (moneyInfo?.viewMoney) {
+    for (let x of moneyInfo.viewMoney) {
+      total += x.amount;
+    }
+    const filpl = moneyInfo.viewMoney.filter((m: MoneyList) => m.amount > 0);
+    for (let x of filpl) {
+      income += x.amount;
+    }
+    const filmi = moneyInfo.viewMoney.filter((m: MoneyList) => m.amount < 0);
+    for (let x of filmi) {
+      expend += x.amount;
+    }
+  }
   return (
     <SummaryBox>
       <MoneyImg src="https://cdn.pixabay.com/photo/2021/06/27/12/40/money-6368673_960_720.png"></MoneyImg>
-      <WelcomeText>こんにちは。(Name)様！</WelcomeText>
+      <WelcomeText>こんにちは。{user}様！</WelcomeText>
       <WelcomeText>今までの収支を確認してください。</WelcomeText>
-      <TotalAmount>￥1,000</TotalAmount>
+      <TotalAmount amount={total}>{`￥${total
+        .toString()
+        .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`}</TotalAmount>
       <AmountDevideBox>
         <Income>
-          <div>入ったお金</div> <span>50,000</span>
+          <div>入ったお金</div>{" "}
+          <span>{`￥${income
+            .toString()
+            .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`}</span>
         </Income>
         <ColDevidedLine></ColDevidedLine>
         <Expend>
           <div>出たお金</div>
-          <span>49,000</span>
+          <span>{`￥${expend
+            .toString()
+            .replace(/\B(?=(\d{3})+(?!\d))/g, ",")}`}</span>
         </Expend>
       </AmountDevideBox>
     </SummaryBox>

--- a/src/components/homeStyle/Navbar.tsx
+++ b/src/components/homeStyle/Navbar.tsx
@@ -1,4 +1,4 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import { logUserOut } from "../../apollo";
 import SvgIcon from "../SvgIcon";
@@ -44,6 +44,7 @@ const Button = styled.button`
   }
 `;
 const Navbar = () => {
+  const navigate = useNavigate();
   return (
     <Container>
       <Wrapper>
@@ -95,7 +96,11 @@ const Navbar = () => {
               </svg>
             </SvgIcon>
 
-            <Button onClick={logUserOut}>ログアウト</Button>
+            <Button
+              onClick={() => (logUserOut(), navigate("/", { replace: true }))}
+            >
+              ログアウト
+            </Button>
           </>
         </Col>
       </Wrapper>

--- a/src/routes/pages/Home.tsx
+++ b/src/routes/pages/Home.tsx
@@ -46,6 +46,7 @@ const ThickDevide = styled.div`
 export const VIEW_MONEY_QUERY = gql`
   query viewMoney($year: Int!, $month: Int) {
     viewMoney(year: $year, month: $month) {
+      id
       title
       amount
       date
@@ -65,19 +66,20 @@ export const CURRENT_USER = gql`
 const Home: React.FC = () => {
   const clickedMonth = useReactiveVar(displayMonth);
   const clickedYear = useReactiveVar(displayYear);
-  const sameThisYM = () => {
-    return (
-      clickedYear.year === new Date().getFullYear() &&
-      clickedMonth.month === new Date().getMonth() + 1
-    );
-  };
+  const { data: loginUser } = useQuery(CURRENT_USER);
+  const { data: moneyInfo } = useQuery(VIEW_MONEY_QUERY, {
+    variables: {
+      year: clickedYear.year,
+      month: clickedMonth.month,
+    },
+  });
 
   return (
     <Container>
       <InnerContainer>
         <ContentBox>
           <HomeDateSelector />
-          <HomeSummary />
+          <HomeSummary user={loginUser?.currentUser?.name} />
           <ThickDevide />
         </ContentBox>
       </InnerContainer>

--- a/src/routes/pages/Home.tsx
+++ b/src/routes/pages/Home.tsx
@@ -1,6 +1,6 @@
 import { gql, useQuery, useReactiveVar } from "@apollo/client";
 import styled from "styled-components";
-import { nextMonth, displayMonth, displayYear, preMonth } from "../../apollo";
+import { displayMonth, displayYear } from "../../apollo";
 import HomeDateSelector from "../../components/homeStyle/HomeDateSelector";
 import HomeSummary from "../../components/homeStyle/HomeSummary";
 

--- a/src/routes/pages/Home.tsx
+++ b/src/routes/pages/Home.tsx
@@ -3,8 +3,6 @@ import styled from "styled-components";
 import { nextMonth, displayMonth, displayYear, preMonth } from "../../apollo";
 import HomeDateSelector from "../../components/homeStyle/HomeDateSelector";
 import HomeSummary from "../../components/homeStyle/HomeSummary";
-import OnlyDevidedLine from "../../components/OnlyDevidedLine";
-import SvgIcon from "../../components/SvgIcon";
 
 const Container = styled.div`
   width: 90%;


### PR DESCRIPTION
6f299213b06cb7d8d0dbc913baf5d0ec5df62789 add real data in HomeSummary
84da024888474247c7b2b222fa2fb0b9d9af0ea0 fixed logout bug
5d5ad96ff03ee794e75514d2deb4c573aecc2e91 add reload when user loggedIn
３つです。
+  8218a31 訂正したMainをpullしたものです。
[d329a4c](https://github.com/ezdar2743/re-intern-FE/pull/4/commits/d329a4ccad7aa4b97ea0de53e9862edab7af8052)
![스크린샷 2022-05-16 09 49 30](https://user-images.githubusercontent.com/81250000/168502468-fed8cf74-d094-4ad9-b744-af2a85757ec0.png)
# 何を実装したか
Dummyだった全てのデータをbackendデータに変えました。
そして、ログインする時、前のuserの情報が出るbugがあり、window.location.reload関数を入れました。
ログアウトをした時会員登録した後送ったID,password情報が残り、useNavigateを利用し、解決しました。
# 出来なかったこと、気になったこと
 let total = 0;
  let income = 0;
  let expend = 0;
このように処理し、見せますが少し臭いコードであると思いました。
前のuserのものが残っている時、window reload以外方法があるか気になりました。
